### PR TITLE
Update authorityConfig.json add two sources from github

### DIFF
--- a/static/authorityConfig.json
+++ b/static/authorityConfig.json
@@ -1805,5 +1805,15 @@
     "label": "NatLibFi test",
     "uri": "file:/natlibfiTest.json",
     "component": "list"
+  },
+  {
+    "label": "mts m777 RDA Media Types",
+    "uri": "https://raw.githubusercontent.com/NatLibFi/lkd/refs/heads/main/test/m777_RDAMediaTypes.json",
+    "component": "list"
+  },
+  {
+    "label": "mts list test",
+    "uri": "https://raw.githubusercontent.com/NatLibFi/lkd/refs/heads/main/test/list_test.json",
+    "component": "list"
   }
 ]


### PR DESCRIPTION
added to the bottom of the list two authority sources of type "list" pointing to  json files in the github.com/NatLibFi/lkd/ repository

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



