### PR TITLE
Update authorityConfig.json - lisätty uusi local viittaus -+- ladattu myös uusi  json tiedosto

### DIFF
--- a/static/authorityConfig.json
+++ b/static/authorityConfig.json
@@ -1825,5 +1825,10 @@
     "label": "mts list test",
     "uri": "https://raw.githubusercontent.com/NatLibFi/lkd/refs/heads/main/test/list_test.json",
     "component": "list"
+  },
+  {
+    "label": "mts finto api MediaTypes - local",
+    "uri": "file:finto_api_mts_m777_MediaType.json",
+    "component": "list"
   }
 ]


### PR DESCRIPTION
uusi yritys  api.finto.fi  swaggerin tuottama .json listaus.

CURL
curl -X GET --header 'Accept: application/ld+json' 'https://api.finto.fi/rest/v1/mts/groupMembers?uri=http%3A%2F%2Furn.fi%2FURN%3ANBN%3Afi%3Aau%3Amts%3Am777&lang=fi'

REQUEST URL
https://api.finto.fi/rest/v1/mts/groupMembers?uri=http%3A%2F%2Furn.fi%2FURN%3ANBN%3Afi%3Aau%3Amts%3Am777&lang=fi

Tuloksessa korvattu manuaalisesti "prefLabel"  arvolla "label"
- voisikohan tämän tehdä jo kutsussa?
- ellei, niin curl-tuloksen voisi ohjata putkeen joka tekee tuon korvauksen tiedostossa.  --- edellytyksellä, että tämä paikallinen listaus toimii Sinopia lomakkeen pudotusvalikossa.

## Why was this change made?

Loin uuden tiedoston, joka on lähes  identtinen Finton APIsta saatavan listauksen kanssa. 
- Vaihdoin ainoastaan yhden kentän nimen "prefLabel" :  muotoon "label" :

## How was this change tested?
- ei testattu


## Which documentation and/or configurations were updated?
- muihin tiedostoihin ei koskettu. Kun tämä tulee näkyviin auktorisoitujen 


