### PR TITLE
Update authorityConfig.json  korjaus  2 linkkiin

### DIFF
--- a/static/authorityConfig.json
+++ b/static/authorityConfig.json
@@ -1818,12 +1818,12 @@
   },
   {
     "label": "mts m777 RDA Media Types",
-    "uri": "https://raw.githubusercontent.com/NatLibFi/lkd/refs/heads/main/test/m777_RDAMediaTypes.json",
+    "uri": "https://raw.githubusercontent.com/NatLibFi/lkd/refs/heads/main/test/m777_RDAMediaTypes",
     "component": "list"
   },
   {
     "label": "mts list test",
-    "uri": "https://raw.githubusercontent.com/NatLibFi/lkd/refs/heads/main/test/list_test.json",
+    "uri": "https://raw.githubusercontent.com/NatLibFi/lkd/refs/heads/main/test/list_test",
     "component": "list"
   }
 ]


### PR DESCRIPTION
Jeremy Nelsonin vinkin perusteella poistin .json -päätteen kahdesta   tidoston lopussa olevasta githubiin viittavasta authority lähteestä 

Kokeillaan sitten uudestaan.

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



